### PR TITLE
Orderbookv1.1

### DIFF
--- a/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/Extensions.cs
+++ b/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/Extensions.cs
@@ -1,0 +1,30 @@
+﻿using System.Numerics;
+using Neo;
+using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Attributes;
+
+namespace FlamingoSwapOrderBook
+{
+    public static class Extensions
+    {
+        /// <summary>
+        /// uint160 转为正整数,用于合约地址排序，其它场景勿用 
+        /// </summary>
+        /// <param name="val">合约地址</param>
+        /// <returns></returns>
+        [OpCode(OpCode.PUSHDATA1, "0100")]
+        [OpCode(OpCode.CAT)]
+        [OpCode(OpCode.CONVERT, "21")]
+        public static extern BigInteger ToUInteger(this UInt160 val);
+
+        /// <summary>
+        /// Is Valid and not Zero address
+        /// </summary>
+        /// <param name="address"></param>
+        /// <returns></returns>
+        public static bool IsAddress(this UInt160 address)
+        {
+            return address.IsValid && !address.IsZero;
+        }
+    }
+}

--- a/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBook.csproj
+++ b/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBook.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Neo3.Compiler.CSharp.Dev" Version="3.1.0" />
+        <PackageReference Include="Neo.SmartContract.Framework" Version="3.1.0" />
+    </ItemGroup>
+    <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+        <Exec Command="$(neon3) $(ProjectDir)" />
+    </Target>
+</Project>

--- a/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBookContract.Admin.cs
+++ b/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBookContract.Admin.cs
@@ -1,0 +1,109 @@
+using Neo;
+using Neo.SmartContract;
+using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Attributes;
+using Neo.SmartContract.Framework.Native;
+using Neo.SmartContract.Framework.Services;
+
+namespace FlamingoSwapOrderBook
+{
+    public partial class FlamingoSwapOrderBookContract
+    {
+        #region Admin
+
+#warning Update the admin address if necessary
+        [InitialValue("NdrUjmLFCmr6RjM52njho5sFUeeTdKPxG9", ContractParameterType.Hash160)]
+        static readonly UInt160 superAdmin = default;
+
+        [InitialValue("0xc0695bdb8a87a40aff33c73ff6349ccc05fa9f01", ContractParameterType.Hash160)]
+        static readonly UInt160 Factory = default;
+
+        [InitialValue("0x48c40d4666f93408be1bef038b6722404d9a4c2a", ContractParameterType.Hash160)]
+        static readonly UInt160 bNEO = default;
+
+        private const string AdminKey = nameof(superAdmin);
+        private const string GASAdminKey = nameof(GASAdminKey);
+        private const string FundAddresskey = nameof(FundAddresskey);
+
+        private static readonly byte[] OrderIDKey = new byte[] { 0x00 };
+        private static readonly byte[] BookMapPrefix = new byte[] { 0x01 };
+        private static readonly byte[] OrderMapPrefix = new byte[] { 0x02 };
+        private static readonly byte[] ReceiptMapPrefix = new byte[] { 0x03 };
+        private static readonly byte[] PauseMapPrefix = new byte[] { 0x04 };
+
+        // When this contract address is included in the transaction signature,
+        // this method will be triggered as a VerificationTrigger to verify that the signature is correct.
+        // For example, this method needs to be called when withdrawing token from the contract.
+        [Safe]
+        public static bool Verify() => Runtime.CheckWitness(GetAdmin());
+
+        [Safe]
+        public static UInt160 GetAdmin()
+        {
+            var admin = Storage.Get(Storage.CurrentReadOnlyContext, AdminKey);
+            return admin?.Length == 20 ? (UInt160)admin : superAdmin;
+        }
+
+        public static bool SetAdmin(UInt160 admin)
+        {
+            Assert(Verify(), "No Authorization");
+            Assert(admin.IsAddress(), "Invalid Address");
+            Storage.Put(Storage.CurrentContext, AdminKey, admin);
+            return true;
+        }
+
+        public static void ClaimGASFrombNEO(UInt160 receiveAddress)
+        {
+            Assert(Runtime.CheckWitness(GetGASAdmin()), "Forbidden");
+            var me = Runtime.ExecutingScriptHash;
+            var beforeBalance = GAS.BalanceOf(me);
+            Assert((bool)Contract.Call(bNEO, "transfer", CallFlags.All, Runtime.ExecutingScriptHash, bNEO, 0, null), "claim fail");
+            var afterBalance = GAS.BalanceOf(me);
+
+            GAS.Transfer(me, receiveAddress, afterBalance - beforeBalance);
+        }
+
+        [Safe]
+        public static UInt160 GetGASAdmin()
+        {
+            var address = Storage.Get(Storage.CurrentReadOnlyContext, GASAdminKey);
+            return address?.Length == 20 ? (UInt160)address : null;
+        }
+
+        public static bool SetGASAdmin(UInt160 GASAdmin)
+        {
+            Assert(GASAdmin.IsAddress(), "Invalid Address");
+            Assert(Verify(), "No Authorization");
+            Storage.Put(Storage.CurrentContext, GASAdminKey, GASAdmin);
+            return true;
+        }
+        #endregion
+
+        #region FundFee
+
+        [Safe]
+        public static UInt160 GetFundAddress()
+        {
+            var address = Storage.Get(Storage.CurrentReadOnlyContext, FundAddresskey);
+            return address?.Length == 20 ? (UInt160)address : null;
+        }
+
+        public static bool SetFundAddress(UInt160 address)
+        {
+            Assert(address.IsAddress(), "Invalid Address");
+            Assert(Verify(), "No Authorization");
+            Storage.Put(Storage.CurrentContext, FundAddresskey, address);
+            return true;
+        }
+        #endregion
+
+        #region Upgrade
+
+        public static void Update(ByteString nefFile, string manifest)
+        {
+            Assert(Verify(), "No Authorization");
+            ContractManagement.Update(nefFile, manifest, null);
+        }
+        #endregion
+    }
+}

--- a/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBookContract.Admin.cs
+++ b/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBookContract.Admin.cs
@@ -30,6 +30,7 @@ namespace FlamingoSwapOrderBook
         private static readonly byte[] OrderMapPrefix = new byte[] { 0x02 };
         private static readonly byte[] ReceiptMapPrefix = new byte[] { 0x03 };
         private static readonly byte[] PauseMapPrefix = new byte[] { 0x04 };
+        private static readonly byte[] FeeMapPrefix = new byte[] { 0x05 };
 
         // When this contract address is included in the transaction signature,
         // this method will be triggered as a VerificationTrigger to verify that the signature is correct.

--- a/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBookContract.Event.cs
+++ b/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBookContract.Event.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel;
+using System.Numerics;
+using Neo;
+using Neo.SmartContract.Framework;
+
+namespace FlamingoSwapOrderBook
+{
+    public partial class FlamingoSwapOrderBookContract
+    {
+        /// <summary>
+        /// When orderbook status changed
+        /// </summary>
+        [DisplayName("BookStatusChanged")]
+        public static event BookStatusChangedEvent onBookStatusChanged;
+        public delegate void BookStatusChangedEvent(UInt160 baseToken, UInt160 quoteToken, BigInteger quoteScale, BigInteger minOrderAmount, BigInteger maxOrderAmount, bool isPaused);
+
+        /// <summary>
+        /// When order status changed
+        /// </summary>
+        [DisplayName("OrderStatusChanged")]
+        public static event OrderStatusChangedEvent onOrderStatusChanged;
+        public delegate void OrderStatusChangedEvent(UInt160 baseToken, UInt160 quoteToken, ByteString id, bool isBuy, UInt160 maker, BigInteger price, BigInteger leftAmount);
+    }
+}

--- a/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBookContract.Helper.cs
+++ b/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBookContract.Helper.cs
@@ -353,6 +353,39 @@ namespace FlamingoSwapOrderBook
         }
 
         /// <summary>
+        /// Stage the fundfee payment for later claim
+        /// </summary>
+        /// <param name="token"></param>
+        /// <param name="amount"></param>
+        private static void StageFundFee(UInt160 token, BigInteger amount)
+        {
+            Assert(amount >= 0, "Invalid Fee Amount");
+            StorageMap feeMap = new(Storage.CurrentContext, FeeMapPrefix);
+            feeMap.Put(token, (BigInteger)feeMap.Get(token) + amount);
+        }
+
+        /// <summary>
+        /// Get staged fundfee amount
+        /// </summary>
+        /// <param name="token"></param>
+        /// <returns></returns>
+        private static BigInteger GetStagedFundFee(UInt160 token)
+        {
+            StorageMap feeMap = new(Storage.CurrentReadOnlyContext, FeeMapPrefix);
+            return (BigInteger)feeMap.Get(token);
+        }
+
+        /// <summary>
+        /// Reset the staged fundfee amount to 0
+        /// </summary>
+        /// <param name="token"></param>
+        private static void CleanStagedFundFee(UInt160 token)
+        {
+            StorageMap feeMap = new(Storage.CurrentContext, FeeMapPrefix);
+            feeMap.Delete(token);
+        }
+
+        /// <summary>
         /// Find a random number as order ID 
         /// </summary>
         /// <returns></returns>

--- a/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBookContract.Helper.cs
+++ b/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBookContract.Helper.cs
@@ -254,7 +254,8 @@ namespace FlamingoSwapOrderBook
         private static LimitOrder GetOrder(ByteString id)
         {
             StorageMap orderMap = new(Storage.CurrentReadOnlyContext, OrderMapPrefix);
-            return (LimitOrder)StdLib.Deserialize(orderMap.Get(id));
+            var order = orderMap.Get(id);
+            return order is null ? new LimitOrder() : (LimitOrder)StdLib.Deserialize(order);
         }
 
         /// <summary>
@@ -287,7 +288,8 @@ namespace FlamingoSwapOrderBook
         private static OrderReceipt GetReceipt(UInt160 maker, ByteString id)
         {
             StorageMap receiptMap = new(Storage.CurrentReadOnlyContext, ReceiptMapPrefix);
-            return (OrderReceipt)StdLib.Deserialize(receiptMap.Get(maker + id));
+            var receipt = receiptMap.Get(maker + id);
+            return receipt is null ? new OrderReceipt() : (OrderReceipt)StdLib.Deserialize(receipt);
         }
 
         /// <summary>
@@ -335,7 +337,8 @@ namespace FlamingoSwapOrderBook
         private static OrderBook GetOrderBook(byte[] pairKey)
         {
             StorageMap bookMap = new(Storage.CurrentReadOnlyContext, BookMapPrefix);
-            return (OrderBook)StdLib.Deserialize(bookMap.Get(pairKey));
+            var book = bookMap.Get(pairKey);
+            return book is null ? new OrderBook() : (OrderBook)StdLib.Deserialize(book);
         }
 
         /// <summary>

--- a/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBookContract.Helper.cs
+++ b/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBookContract.Helper.cs
@@ -1,0 +1,499 @@
+using Neo;
+using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Attributes;
+using Neo.SmartContract.Framework.Native;
+using Neo.SmartContract.Framework.Services;
+using System;
+using System.Numerics;
+
+namespace FlamingoSwapOrderBook
+{
+    public partial class FlamingoSwapOrderBookContract
+    {
+        /// <summary>
+        /// Insert a not-fully-deal limit order into orderbook
+        /// </summary>
+        /// <param name="pairKey"></param>
+        /// <param name="book"></param>
+        /// <param name="id"></param>
+        /// <param name="order"></param>
+        /// <param name="isBuy"></param>
+        /// <returns></returns>
+        private static bool InsertOrder(byte[] pairKey, OrderBook book, ByteString id, LimitOrder order, bool isBuy)
+        {
+            var firstID = isBuy ? book.firstBuyID : book.firstSellID;
+
+            // Check if there is no order
+            var canBeFirst = firstID is null;
+            if (!canBeFirst)
+            {
+                // Check if this order is the worthiest
+                var firstOrder = GetOrder(firstID);
+                canBeFirst = (isBuy && (firstOrder.price < order.price)) || (!isBuy && (firstOrder.price > order.price));
+            }
+            if (canBeFirst)
+            {
+                // Insert to the first
+                if (isBuy) book.firstBuyID = id;
+                else book.firstSellID = id;
+                SetOrderBook(pairKey, book);
+                order.nextID = firstID;
+                SetOrder(id, order);
+                return true;
+            }
+            else
+            {
+                // Find the position
+                return InsertNotFirst(firstID, id, order, isBuy);
+            }
+        }
+
+        private static bool InsertNotFirst(ByteString firstID, ByteString id, LimitOrder order, bool isBuy)
+        {
+            var currentID = firstID; 
+            while (currentID is not null)
+            {
+                // Check before
+                var currentOrder = GetOrder(currentID);
+                var canFollow = (isBuy && (order.price <= currentOrder.price)) || (!isBuy && (order.price >= currentOrder.price));
+                if (!canFollow) break;
+
+                if (currentOrder.nextID is not null)
+                {
+                    // Check after
+                    var nextOrder = GetOrder(currentOrder.nextID);
+                    var canPrecede = (isBuy && (nextOrder.price < order.price)) || (!isBuy && (nextOrder.price > order.price));
+                    canFollow = canFollow && canPrecede;
+                }
+                if (canFollow)
+                {
+                    // Do insert
+                    order.nextID = currentOrder.nextID;
+                    SetOrder(id, order);
+                    currentOrder.nextID = id;
+                    SetOrder(currentID, currentOrder);
+                    return true;
+                }
+                currentID = currentOrder.nextID;
+            }
+            return false;
+        }
+
+        private static bool InsertOrderAt(ByteString parentID, ByteString id, LimitOrder order, bool isBuy)
+        {
+            var parentOrder = GetOrder(parentID);
+            var canFollow = (isBuy && (order.price <= parentOrder.price)) || (!isBuy && (order.price >= parentOrder.price));
+            if (!canFollow) return false;
+            
+            if (parentOrder.nextID is not null)
+            {
+                // Check after
+                var nextOrder = GetOrder(parentOrder.nextID);
+                var canPrecede = (isBuy && (nextOrder.price < order.price)) || (!isBuy && (nextOrder.price > order.price));
+                canFollow = canFollow && canPrecede;
+            }
+            if (canFollow)
+            {
+                // Do insert
+                order.nextID = parentOrder.nextID;
+                SetOrder(id, order);
+                parentOrder.nextID = id;
+                SetOrder(parentID, parentOrder);
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Get the parent order id
+        /// </summary>
+        /// <param name="pairKey"></param>
+        /// <param name="isBuy"></param>
+        /// <param name="childID"></param>
+        /// <returns></returns>
+        private static ByteString GetParentID(byte[] pairKey, bool isBuy, ByteString childID)
+        {
+            var book = GetOrderBook(pairKey);
+            var firstID = isBuy ? book.firstBuyID : book.firstSellID;
+            if (firstID == childID) return null;
+
+            var currentID = firstID;
+            while (currentID is not null)
+            {
+                var currentOrder = GetOrder(currentID);
+                if (currentOrder.nextID == childID) return currentID;
+                currentID = currentOrder.nextID;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Remove a canceled limit order from orderbook
+        /// </summary>
+        /// <param name="pairKey"></param>
+        /// <param name="book"></param>
+        /// <param name="id"></param>
+        /// <param name="isBuy"></param>
+        /// <returns></returns>
+        private static bool RemoveOrder(byte[] pairKey, OrderBook book, ByteString id, bool isBuy)
+        {
+            // Remove from BookMap
+            var firstID = isBuy ? book.firstBuyID : book.firstSellID;
+            if (firstID is null) return false;
+            if (firstID == id)
+            {
+                // Delete the first
+                if (isBuy) book.firstBuyID = GetOrder(firstID).nextID;
+                else book.firstSellID = GetOrder(firstID).nextID;
+                SetOrderBook(pairKey, book);
+                DeleteOrder(firstID);
+                return true;
+            }
+            else
+            {
+                // Find the position
+                return RemoveNotFirst(firstID, id);
+            }
+        }
+
+        private static bool RemoveNotFirst(ByteString firstID, ByteString id)
+        {
+            var currentID = firstID; 
+            var currentOrder = GetOrder(currentID);
+            while (currentOrder.nextID is not null)
+            {
+                // Check next
+                if (currentOrder.nextID == id)
+                {
+                    // Do remove
+                    var newNextID = GetOrder(currentOrder.nextID).nextID;
+                    DeleteOrder(currentOrder.nextID);
+                    currentOrder.nextID = newNextID;
+                    SetOrder(currentID, currentOrder);
+                    return true;
+                }
+                currentID = currentOrder.nextID;
+                currentOrder = GetOrder(currentID);
+            }
+            return false;
+        }
+
+        private static bool RemoveOrderAt(ByteString parentID, ByteString id)
+        {
+            var parentOrder = GetOrder(parentID);
+            if (parentOrder.nextID != id) return false;
+
+            // Do remove
+            var newNextID = GetOrder(id).nextID;
+            DeleteOrder(id);
+            parentOrder.nextID = newNextID;
+            SetOrder(parentID, parentOrder);
+            return true;
+        }
+
+        /// <summary>
+        /// Check if a limit order exists
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        private static bool OrderExists(ByteString id)
+        {
+            StorageMap orderMap = new(Storage.CurrentReadOnlyContext, OrderMapPrefix);
+            return orderMap.Get(id) is not null;
+        }
+
+        /// <summary>
+        /// Check if an order book exists
+        /// </summary>
+        /// <param name="pairKey"></param>
+        /// <returns></returns>
+        private static bool BookExists(byte[] pairKey)
+        {
+            StorageMap bookMap = new(Storage.CurrentReadOnlyContext, BookMapPrefix);
+            return bookMap.Get(pairKey) is not null;
+        }
+
+        /// <summary>
+        /// Set an order book as paused
+        /// </summary>
+        /// <param name="pairKey"></param>
+        /// <returns></returns>
+        private static void SetPaused(byte[] pairKey)
+        {
+            StorageMap pauseMap = new(Storage.CurrentContext, PauseMapPrefix);
+            pauseMap.Put(pairKey, 1);
+        }
+
+        /// <summary>
+        /// Remove an order book from paused
+        /// </summary>
+        /// <param name="pairKey"></param>
+        /// <returns></returns>
+        private static void RemovePaused(byte[] pairKey)
+        {
+            StorageMap pauseMap = new(Storage.CurrentContext, PauseMapPrefix);
+            pauseMap.Delete(pairKey);
+        }
+
+        /// <summary>
+        /// Check if an order book is paused
+        /// </summary>
+        /// <param name="pairKey"></param>
+        /// <returns></returns>
+        private static bool BookPaused(byte[] pairKey)
+        {
+            StorageMap pauseMap = new(Storage.CurrentReadOnlyContext, PauseMapPrefix);
+            return pauseMap.Get(pairKey) is not null;
+        }
+
+        /// <summary>
+        /// Get the detail of a limit order 
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        private static LimitOrder GetOrder(ByteString id)
+        {
+            StorageMap orderMap = new(Storage.CurrentReadOnlyContext, OrderMapPrefix);
+            return (LimitOrder)StdLib.Deserialize(orderMap.Get(id));
+        }
+
+        /// <summary>
+        /// Update a limit order 
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="order"></param>
+        private static void SetOrder(ByteString id, LimitOrder order)
+        {
+            StorageMap orderMap = new(Storage.CurrentContext, OrderMapPrefix);
+            orderMap.Put(id, StdLib.Serialize(order));
+        }
+
+        /// <summary>
+        /// Delete a limit order 
+        /// </summary>
+        /// <param name="id"></param>
+        private static void DeleteOrder(ByteString id)
+        {
+            StorageMap orderMap = new(Storage.CurrentContext, OrderMapPrefix);
+            orderMap.Delete(id);
+        }
+
+        /// <summary>
+        /// Get the detail of an order receipt
+        /// </summary>
+        /// <param name="maker"></param>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        private static OrderReceipt GetReceipt(UInt160 maker, ByteString id)
+        {
+            StorageMap receiptMap = new(Storage.CurrentReadOnlyContext, ReceiptMapPrefix);
+            return (OrderReceipt)StdLib.Deserialize(receiptMap.Get(maker + id));
+        }
+
+        /// <summary>
+        /// Get all receipts of the maker
+        /// </summary>
+        /// <param name="maker"></param>
+        /// <returns></returns>
+        private static Iterator ReceiptsOf(UInt160 maker)
+        {
+            StorageMap receiptMap = new(Storage.CurrentReadOnlyContext, ReceiptMapPrefix);
+            return receiptMap.Find(maker, FindOptions.ValuesOnly | FindOptions.DeserializeValues);
+        }
+
+        [OpCode(OpCode.APPEND)]
+        private static extern void Append<T>(T[] array, T newItem);
+
+        /// <summary>
+        /// Update an order receipt
+        /// </summary>
+        /// <param name="maker"></param>
+        /// <param name="id"></param>
+        /// <param name="receipt"></param>
+        private static void SetReceipt(UInt160 maker, ByteString id, OrderReceipt receipt)
+        {
+            StorageMap receiptMap = new(Storage.CurrentContext, ReceiptMapPrefix);
+            receiptMap.Put(maker + id, StdLib.Serialize(receipt));
+        }
+
+        /// <summary>
+        /// Delete an order receipt
+        /// </summary>
+        /// <param name="maker"></param>
+        /// <param name="id"></param>
+        private static void DeleteReceipt(UInt160 maker, ByteString id)
+        {
+            StorageMap receiptMap = new(Storage.CurrentContext, ReceiptMapPrefix);
+            receiptMap.Delete(maker + id);
+        }
+
+        /// <summary>
+        /// Get the detail of a book 
+        /// </summary>
+        /// <param name="pairKey"></param>
+        /// <returns></returns>
+        private static OrderBook GetOrderBook(byte[] pairKey)
+        {
+            StorageMap bookMap = new(Storage.CurrentReadOnlyContext, BookMapPrefix);
+            return (OrderBook)StdLib.Deserialize(bookMap.Get(pairKey));
+        }
+
+        /// <summary>
+        /// Update a book 
+        /// </summary>
+        /// <param name="pairKey"></param>
+        /// <param name="book"></param>
+        private static void SetOrderBook(byte[] pairKey, OrderBook book)
+        {
+            StorageMap bookMap = new(Storage.CurrentContext, BookMapPrefix);
+            bookMap.Put(pairKey, StdLib.Serialize(book));
+        }
+
+        /// <summary>
+        /// Find a random number as order ID 
+        /// </summary>
+        /// <returns></returns>
+        private static ByteString GetUnusedID()
+        {
+            StorageContext context = Storage.CurrentContext;
+            ByteString counter = Storage.Get(context, OrderIDKey);
+            Storage.Put(context, OrderIDKey, (BigInteger)counter + 1);
+            ByteString data = Runtime.ExecutingScriptHash;
+            if (counter is not null) data += counter;
+            return CryptoLib.Sha256(data);
+        }
+
+        /// <summary>
+        /// Get the pair contract
+        /// </summary>
+        /// <param name="tokenA"></param>
+        /// <param name="tokenB"></param>
+        /// <returns></returns>
+        public static UInt160 GetExchangePairWithAssert(UInt160 tokenA, UInt160 tokenB)
+        {
+            Assert(tokenA.IsValid && tokenB.IsValid, "Invalid A or B Address");
+            var pairContract = (byte[])Contract.Call(Factory, "getExchangePair", CallFlags.ReadOnly, new object[] { tokenA, tokenB });
+            Assert(pairContract != null && pairContract.Length == 20, "PairContract Not Found", tokenA, tokenB);
+            return (UInt160)pairContract;
+        }
+
+        /// <summary>
+        /// Get TokenA and TokenB reserves from paicontract
+        /// </summary>
+        /// <param name="pairContract"></param>
+        /// <param name="tokenA"></param>
+        /// <param name="tokenB"></param>
+        /// <returns></returns>
+        public static BigInteger[] GetReserves(UInt160 pairContract, UInt160 tokenA, UInt160 tokenB)
+        {
+            var reserveData = (ReservesData)Contract.Call(pairContract, "getReserves", CallFlags.ReadOnly, new object[] { });
+            return tokenA.ToUInteger() < tokenB.ToUInteger() ? new BigInteger[] { reserveData.Reserve0, reserveData.Reserve1 } : new BigInteger[] { reserveData.Reserve1, reserveData.Reserve0 };
+        }
+
+        /// <summary>
+        /// Check if pair contract charge a fundfee
+        /// </summary>
+        /// <param name="pairContract"></param>
+        /// <returns></returns>
+        public static bool HasFundAddress(UInt160 pairContract)
+        {
+            return (byte[])Contract.Call(pairContract, "getFundAddress", CallFlags.ReadOnly, new object[] { }) != null;
+        }
+
+        /// <summary>
+        /// Get amountOut from pair
+        /// </summary>
+        /// <param name="pairContract"></param>
+        /// <param name="amount0Out"></param>
+        /// <param name="amount1Out"></param>
+        /// <param name="toAddress"></param>
+        private static void SwapOut(UInt160 pairContract, BigInteger amount0Out, BigInteger amount1Out, UInt160 toAddress)
+        {
+            Contract.Call(pairContract, "swap", CallFlags.All, new object[] { amount0Out, amount1Out, toAddress, null });
+        }
+
+        /// <summary>
+        /// Transfer NEP-5 tokens
+        /// </summary>
+        /// <param name="token"></param>
+        /// <param name="from"></param>
+        /// <param name="to"></param>
+        /// <param name="amount"></param>
+        /// <param name="data"></param>
+        /// <returns></returns>
+        private static void SafeTransfer(UInt160 token, UInt160 from, UInt160 to, BigInteger amount, byte[] data = null)
+        {
+            try
+            {
+                var result = (bool)Contract.Call(token, "transfer", CallFlags.All, new object[] { from, to, amount, data });
+                Assert(result, "Transfer Fail in OrderBook", token);
+            }
+            catch (Exception)
+            {
+                Assert(false, "Transfer Error in OrderBook", token);
+            }
+        }
+
+        private static void RequestTransfer(UInt160 token, UInt160 from, UInt160 to, BigInteger amount, byte[] data = null)
+        {
+            try
+            {
+                var balanceBefore = GetBalanceOf(token, to);
+                var result = (bool)Contract.Call(from, "approvedTransfer", CallFlags.All, new object[] { token, to, amount, data });
+                var balanceAfter = GetBalanceOf(token, to);
+                Assert(result, "Transfer Not Approved in OrderBook", token);
+                Assert(balanceAfter == balanceBefore + amount, "Unexpected Transfer in OrderBook", token);
+            }
+            catch (Exception)
+            {
+                Assert(false, "Transfer Error in OrderBook", token);
+            }
+        }
+
+        private static BigInteger GetBalanceOf(UInt160 token, UInt160 address)
+        {
+            return (BigInteger)Contract.Call(token, "balanceOf", CallFlags.ReadOnly, new object[] { address });
+        }
+
+        /// <summary>
+        /// Get unique pair key
+        /// </summary>
+        /// <param name="tokenA"></param>
+        /// <param name="tokenB"></param>
+        /// <returns></returns>
+        private static byte[] GetPairKey(UInt160 tokenA, UInt160 tokenB)
+        {
+            return (BigInteger)tokenA < (BigInteger)tokenB
+                ? BookMapPrefix.Concat(tokenA).Concat(tokenB)
+                : BookMapPrefix.Concat(tokenB).Concat(tokenA);
+        }
+
+        /// <summary>
+        /// Check if
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="message"></param>
+        /// <param name="data"></param>
+        private static void Assert(bool condition, string message, object data = null)
+        {
+            if (!condition)
+            {
+                throw new Exception(message);
+            }
+        }
+
+        /// <summary>
+        /// Check if
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="message"></param>
+        /// <param name="data"></param>
+        private static void Assert(bool condition, string message, params object[] data)
+        {
+            if (!condition)
+            {
+                throw new Exception(message);
+            }
+        }
+    }
+}

--- a/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBookContract.cs
+++ b/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBookContract.cs
@@ -1030,7 +1030,7 @@ namespace FlamingoSwapOrderBook
             var isBuy = tokenFrom == book.quoteToken;
 
             var result = MatchOrderInternal(pairKey, isBuy, price, amountIn, !isBuy);
-            return new BigInteger[]{ result[0], result[1] * 997 / 1000 };   // 0.3% fee
+            return new BigInteger[] { result[0], result[1] * 997 / 1000 };   // 0.3% fee
         }
 
         /// <summary>
@@ -1051,7 +1051,7 @@ namespace FlamingoSwapOrderBook
             var isBuy = tokenFrom == book.quoteToken;
 
             var result = MatchOrderInternal(pairKey, isBuy, price, (amountOut * 1000 + 996) / 997, isBuy);   // 0.3% fee
-            return new BigInteger[]{ (result[0] * 997 + 999) / 1000, result[1] + 1 };
+            return isBuy ? new BigInteger[] { result[0] * 997 / 1000, result[1] + 1 } : new BigInteger[]{ (result[0] * 997 + 999) / 1000, result[1] };
         }
         #endregion
 

--- a/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBookContract.cs
+++ b/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBookContract.cs
@@ -909,20 +909,23 @@ namespace FlamingoSwapOrderBook
         /// <summary>
         /// Claim the staged fundfee payment to fund address
         /// </summary>
-        /// <param name="token"></param>
+        /// <param name="tokens"></param>
         /// <returns></returns>
-        public static BigInteger ClaimFundFee(UInt160 token)
+        public static bool ClaimFundFee(UInt160[] tokens)
         {
             var fundAddress = GetFundAddress();
-            if (fundAddress is null) return 0;
-            var amount = GetStagedFundFee(token);
+            if (fundAddress is null) return false;
             var me = Runtime.ExecutingScriptHash;
-            if (amount > 0)
+            foreach (var token in tokens)
             {
-                CleanStagedFundFee(token);
-                SafeTransfer(token, me, fundAddress, amount);
+                var amount = GetStagedFundFee(token);
+                if (amount > 0)
+                {
+                    CleanStagedFundFee(token);
+                    SafeTransfer(token, me, fundAddress, amount);
+                }
             }
-            return amount;
+            return true;
         }
 
         /// <summary>

--- a/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBookContract.cs
+++ b/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBookContract.cs
@@ -444,7 +444,7 @@ namespace FlamingoSwapOrderBook
         }
 
         /// <summary>
-        /// Get first N limit orders and their details
+        /// Get first N limit orders and their details, start from pos
         /// </summary>
         /// <param name="tokenA"></param>
         /// <param name="tokenB"></param>
@@ -483,6 +483,12 @@ namespace FlamingoSwapOrderBook
             return results;
         }
 
+        /// <summary>
+        /// Get first N limit orders and their details, start from orderID
+        /// </summary>
+        /// <param name="orderID"></param>
+        /// <param name="n"></param>
+        /// <returns></returns>
         [Safe]
         public static OrderReceipt[] GetFirstNOrders(ByteString orderID, uint n)
         {
@@ -508,7 +514,7 @@ namespace FlamingoSwapOrderBook
         }
 
         /// <summary>
-        /// Get all orders and their details of maker
+        /// Get N orders of maker and their details, start from pos
         /// </summary>
         /// <param name="maker"></param>
         /// <param name="pos"></param>
@@ -534,6 +540,12 @@ namespace FlamingoSwapOrderBook
             return results;
         }
 
+        /// <summary>
+        /// Get N orders of maker and their details, start from orderID
+        /// </summary>
+        /// <param name="orderID"></param>
+        /// <param name="n"></param>
+        /// <returns></returns>
         [Safe]
         public static OrderReceipt[] GetOrdersOf(ByteString orderID, uint n)
         {
@@ -698,7 +710,7 @@ namespace FlamingoSwapOrderBook
         }
 
         /// <summary>
-        /// Try to make a market deal with orderbook
+        /// Try to make a market deal with orderbook, taker is not a contract
         /// </summary>
         /// <param name="tokenA"></param>
         /// <param name="tokenB"></param>
@@ -719,6 +731,15 @@ namespace FlamingoSwapOrderBook
             return DealMarketOrderInternal(pairKey, taker, isBuy, price, amount, false);
         }
 
+        /// <summary>
+        /// Try to make a market deal with orderbook, taker is a contract
+        /// </summary>
+        /// <param name="tokenA"></param>
+        /// <param name="tokenB"></param>
+        /// <param name="isBuy"></param>
+        /// <param name="price"></param>
+        /// <param name="amount"></param>
+        /// <returns>Left amount</returns>
         public static BigInteger DealMarketOrder(UInt160 tokenA, UInt160 tokenB, bool isBuy, BigInteger price, BigInteger amount)
         {
             // Check parameters
@@ -945,11 +966,30 @@ namespace FlamingoSwapOrderBook
             return GetOrder(firstID).price;
         }
 
+        /// <summary>
+        /// Get trade pair details
+        /// </summary>
+        /// <param name="tokenA"></param>
+        /// <param name="tokenB"></param>
+        /// <returns></returns>
         [Safe]
         public static OrderBook GetBookInfo(UInt160 tokenA, UInt160 tokenB)
         {
             var pairKey = GetPairKey(tokenA, tokenB);
             return GetOrderBook(pairKey);
+        }
+
+        /// <summary>
+        /// Check if a pair of token is tradable
+        /// </summary>
+        /// <param name="tokenA"></param>
+        /// <param name="tokenB"></param>
+        /// <returns></returns>
+        [Safe]
+        public static bool BookTradable(UInt160 tokenA, UInt160 tokenB)
+        {
+            var pairKey = GetPairKey(tokenA, tokenB);
+            return BookExists(pairKey) && !BookPaused(pairKey);
         }
         #endregion
 

--- a/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBookContract.cs
+++ b/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBookContract.cs
@@ -22,9 +22,9 @@ namespace FlamingoSwapOrderBook
         /// <param name="tokenB"></param>
         /// <param name="sender"></param>
         /// <param name="isBuy"></param>
-        /// <param name="amount">Total buy/sell(real get/pay) amount of the limit order</param>
+        /// <param name="amount">Total buy(real get)/sell amount of the limit order</param>
         /// <param name="price">Price limit of the order</param>
-        /// <param name="bookAmount">Expected amount to buy/sell(in-book amount) in book before amm</param>
+        /// <param name="bookAmount">Expected amount to buy(real get)/sell from/to book before amm</param>
         /// <param name="bookPrice">Price limit of bookAmount part</param>
         /// <param name="deadLine"></param>
         /// <returns></returns>
@@ -40,7 +40,7 @@ namespace FlamingoSwapOrderBook
 
             // Market order
             var leftAmount = amount;
-            if (isBuy) leftAmount -= bookAmount > 0 ? (bookAmount - DealMarketOrderInternal(pairKey, sender, isBuy, bookPrice, bookAmount, false)) * 997 / 1000 : 0;
+            if (isBuy) leftAmount -= bookAmount > 0 ? bookAmount - DealMarketOrderInternal(pairKey, sender, isBuy, bookPrice, (bookAmount * 1000 + 996) / 997, false) * 997 / 1000 : 0;
             else leftAmount -= bookAmount > 0 ? bookAmount - DealMarketOrderInternal(pairKey, sender, isBuy, bookPrice, bookAmount, false) : 0;
             if (leftAmount == 0) return null;
 
@@ -109,9 +109,9 @@ namespace FlamingoSwapOrderBook
         /// <param name="tokenB"></param>
         /// <param name="sender"></param>
         /// <param name="isBuy"></param>
-        /// <param name="amount">Total buy/sell(real get/pay) amount of the limit order</param>
-        /// <param name="slippage">The amount limit of final receive/payment(real get/pay)</param>
-        /// <param name="bookAmount">Expected amount to buy/sell(in-book amount) in book before amm</param>
+        /// <param name="amount">Total buy(real get)/sell amount of the limit order</param>
+        /// <param name="slippage">The amount limit of final payment/receive(real get)</param>
+        /// <param name="bookAmount">Expected amount to buy(real get)/sell from/to book before amm</param>
         /// <param name="bookPrice">Price limit of bookAmount part</param>
         /// <param name="deadLine"></param>
         /// <returns></returns>
@@ -133,7 +133,7 @@ namespace FlamingoSwapOrderBook
             if (bookAmount > 0)
             {
                 var balanceBefore = GetBalanceOf(book.quoteToken, sender);
-                if (isBuy) amount -= (bookAmount - DealMarketOrderInternal(pairKey, sender, isBuy, bookPrice, bookAmount, false)) * 997 / 1000;
+                if (isBuy) amount -= bookAmount - DealMarketOrderInternal(pairKey, sender, isBuy, bookPrice, (bookAmount * 1000 + 996) / 997, false) * 997 / 1000;
                 else amount -= bookAmount - DealMarketOrderInternal(pairKey, sender, isBuy, bookPrice, bookAmount, false);
                 var balanceAfter = GetBalanceOf(book.quoteToken, sender);
                 quoteAmount = isBuy ? balanceBefore - balanceAfter : balanceAfter - balanceBefore;

--- a/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBookContract.cs
+++ b/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBookContract.cs
@@ -1,0 +1,990 @@
+﻿using Neo;
+using Neo.SmartContract.Framework;
+using Neo.SmartContract.Framework.Attributes;
+using Neo.SmartContract.Framework.Native;
+using Neo.SmartContract.Framework.Services;
+using System.Numerics;
+using System.ComponentModel;
+
+namespace FlamingoSwapOrderBook
+{
+    [DisplayName("FlamingoSwapOrderBook")]
+    [ManifestExtra("Author", "Flamingo Finance")]
+    [ManifestExtra("Email", "developer@flamingo.finance")]
+    [ManifestExtra("Description", "This is a Flamingo Contract")]
+    [ContractPermission("*")]
+    public partial class FlamingoSwapOrderBookContract : SmartContract
+    {
+        /// <summary>
+        /// Deal and add limit order base on input strategy
+        /// </summary>
+        /// <param name="tokenA"></param>
+        /// <param name="tokenB"></param>
+        /// <param name="sender"></param>
+        /// <param name="isBuy"></param>
+        /// <param name="amount"></param>
+        /// <param name="price"></param>
+        /// <param name="expectBookAmount"></param>
+        /// <returns></returns>
+        public static ByteString RouteLimitOrder(UInt160 tokenA, UInt160 tokenB, UInt160 sender, bool isBuy, BigInteger amount, BigInteger price, BigInteger expectBookAmount)
+        {
+            // Market order
+            var leftAmount = expectBookAmount > 0 ? amount - expectBookAmount + DealMarketOrder(tokenA, tokenB, sender, isBuy, price, expectBookAmount) : amount;
+
+            // Swap AMM
+            var pairKey = GetPairKey(tokenA, tokenB);
+            var book = GetOrderBook(pairKey);
+            var pairContract = GetExchangePairWithAssert(tokenA, tokenB);
+            var hasFundFee = HasFundAddress(pairContract);
+
+            var ammReverse = isBuy
+                ? GetReserves(pairContract, book.quoteToken, book.baseToken)
+                : GetReserves(pairContract, book.baseToken, book.quoteToken);
+            var amountIn = hasFundFee
+                ? GetAmountInTillPriceWithFundFee(isBuy, price, book.quoteScale, ammReverse[0], ammReverse[1])
+                : GetAmountInTillPrice(isBuy, price, book.quoteScale, ammReverse[0], ammReverse[1]);
+            if (amountIn < 0) amountIn = 0;
+            var amountOut = GetAmountOut(amountIn, ammReverse[0], ammReverse[1]);
+
+            if (isBuy && leftAmount < amountOut)
+            {
+                amountOut = leftAmount;
+                amountIn = GetAmountIn(amountOut, ammReverse[0], ammReverse[1]);
+            }
+            if (!isBuy && leftAmount < amountIn)
+            {
+                amountIn = leftAmount;
+                amountOut = GetAmountOut(amountIn, ammReverse[0], ammReverse[1]);
+            }
+
+            if (amountOut > 0) 
+            {
+                SwapAMM(pairContract, sender, isBuy ? book.quoteToken : book.baseToken, isBuy ? book.baseToken : book.quoteToken, amountIn, amountOut);
+                leftAmount -= isBuy ? amountOut : amountIn;
+            }
+
+            // Add limit order
+            if (leftAmount < book.minOrderAmount || leftAmount > book.maxOrderAmount) return null;
+            var me = Runtime.ExecutingScriptHash;
+            if (isBuy) SafeTransfer(book.quoteToken, sender, me, leftAmount * price / book.quoteScale);
+            else SafeTransfer(book.baseToken, sender, me, leftAmount);
+
+            var id = GetUnusedID();
+            Assert(InsertOrder(pairKey, book, id, new LimitOrder(){
+                maker = sender,
+                price = price,
+                amount = leftAmount
+            }, isBuy), "Add Order Fail");
+
+            // Add receipt
+            SetReceipt(sender, id, new OrderReceipt(){
+                baseToken = book.baseToken,
+                quoteToken = book.quoteToken,
+                id = id,
+                time = Runtime.Time,
+                isBuy = isBuy,
+                totalAmount = leftAmount
+            });
+            onOrderStatusChanged(book.baseToken, book.quoteToken, id, !!isBuy, sender, price, leftAmount);
+            return id;
+        }
+
+        /// <summary>
+        /// Deal market order based on input strategy
+        /// </summary>
+        /// <param name="tokenA"></param>
+        /// <param name="tokenB"></param>
+        /// <param name="sender"></param>
+        /// <param name="isBuy"></param>
+        /// <param name="amount"></param>
+        /// <param name="slippage"></param>
+        /// <param name="expectBookAmount"></param>
+        public static void RouteMarketOrder(UInt160 tokenA, UInt160 tokenB, UInt160 sender, bool isBuy, BigInteger amount, BigInteger slippage, BigInteger expectBookAmount)
+        {
+            // Market order
+            var pairKey = GetPairKey(tokenA, tokenB);
+            var book = GetOrderBook(pairKey);
+            var price = slippage * book.quoteScale / amount;
+
+            var balanceBefore = GetBalanceOf(isBuy ? book.quoteToken : book.quoteToken, sender);
+            var leftAmount = expectBookAmount > 0 ? amount - expectBookAmount + DealMarketOrder(tokenA, tokenB, sender, isBuy, price, expectBookAmount) : amount;
+            var balanceAfter = GetBalanceOf(isBuy ? book.quoteToken : book.quoteToken, sender);
+
+            // Swap AMM
+            var pairContract = GetExchangePairWithAssert(tokenA, tokenB);
+            var ammReverse = GetReserves(pairContract, book.baseToken, book.quoteToken);
+
+            var amountIn = isBuy ? GetAmountIn(leftAmount, ammReverse[1], ammReverse[0]) : leftAmount;
+            var amountOut = isBuy ? leftAmount : GetAmountOut(leftAmount, ammReverse[0], ammReverse[1]);
+
+            if (amountOut > 0) SwapAMM(pairContract, sender, isBuy ? book.quoteToken : book.baseToken, isBuy ? book.baseToken : book.quoteToken, amountIn, amountOut);
+            Assert(isBuy ? amountIn + balanceBefore - balanceAfter <= slippage : amountOut + balanceAfter - balanceBefore >= slippage, "Insufficient Slippage");
+        }
+
+        #region DEX like API
+        /// <summary>
+        /// Register a new book
+        /// </summary>
+        /// <param name="baseToken"></param>
+        /// <param name="quoteToken"></param>
+        /// <param name="quoteDecimals"></param>
+        /// <param name="minOrderAmount"></param>
+        /// <param name="maxOrderAmount"></param>
+        public static void RegisterOrderBook(UInt160 baseToken, UInt160 quoteToken, uint quoteDecimals, BigInteger minOrderAmount, BigInteger maxOrderAmount)
+        {
+            Assert(baseToken.IsAddress() && quoteToken.IsAddress(), "Invalid Address");
+            Assert(baseToken != quoteToken, "Invalid Trade Pair");
+            Assert(minOrderAmount > 0 && maxOrderAmount > 0 && minOrderAmount <= maxOrderAmount, "Invalid Amount Limit");
+            Assert(Verify(), "No Authorization");
+
+            var pairKey = GetPairKey(baseToken, quoteToken);
+            var quoteScale = BigInteger.Pow(10, (int)quoteDecimals);
+            Assert(!BookExists(pairKey), "Book Already Registered");
+            SetOrderBook(pairKey, new OrderBook(){
+                baseToken = baseToken,
+                quoteToken = quoteToken,
+                quoteScale = quoteScale,
+                minOrderAmount = minOrderAmount,
+                maxOrderAmount = maxOrderAmount
+            });
+            onBookStatusChanged(baseToken, quoteToken, quoteScale, minOrderAmount, maxOrderAmount, BookPaused(pairKey));
+        }
+
+        /// <summary>
+        /// Set the minimum order amount for addLimitOrder
+        /// </summary>
+        /// <param name="baseToken"></param>
+        /// <param name="quoteToken"></param>
+        /// <param name="minOrderAmount"></param>
+        public static void SetMinOrderAmount(UInt160 baseToken, UInt160 quoteToken, BigInteger minOrderAmount)
+        {
+            Assert(baseToken.IsAddress() && quoteToken.IsAddress(), "Invalid Address");
+            Assert(minOrderAmount > 0, "Invalid Amount Limit");
+            Assert(Verify(), "No Authorization");
+
+            var pairKey = GetPairKey(baseToken, quoteToken);
+            var book = GetOrderBook(pairKey);
+            Assert(book.baseToken == baseToken && book.quoteToken == quoteToken, "Invalid Trade Pair");
+            Assert(minOrderAmount <= book.maxOrderAmount, "Invalid Amount Limit");
+
+            book.minOrderAmount = minOrderAmount;
+            SetOrderBook(pairKey, book);
+            onBookStatusChanged(book.baseToken, book.quoteToken, book.quoteScale, book.minOrderAmount, book.maxOrderAmount, BookPaused(pairKey));
+        }
+
+        /// <summary>
+        /// Set the maximum trade amount for addLimitOrder
+        /// </summary>
+        /// <param name="baseToken"></param>
+        /// <param name="quoteToken"></param>
+        /// <param name="maxOrderAmount"></param>
+        public static void SetMaxOrderAmount(UInt160 baseToken, UInt160 quoteToken, BigInteger maxOrderAmount)
+        {
+            Assert(baseToken.IsAddress() && quoteToken.IsAddress(), "Invalid Address");
+            Assert(maxOrderAmount > 0, "Invalid Amount Limit");
+            Assert(Verify(), "No Authorization");
+
+            var pairKey = GetPairKey(baseToken, quoteToken);
+            var book = GetOrderBook(pairKey);
+            Assert(book.baseToken == baseToken && book.quoteToken == quoteToken, "Invalid Trade Pair");
+            Assert(maxOrderAmount >= book.minOrderAmount, "Invalid Amount Limit");
+
+            book.maxOrderAmount = maxOrderAmount;
+            SetOrderBook(pairKey, book);
+            onBookStatusChanged(book.baseToken, book.quoteToken, book.quoteScale, book.minOrderAmount, book.maxOrderAmount, BookPaused(pairKey));
+        }
+
+        /// <summary>
+        /// Pause an existing order book
+        /// </summary>
+        /// <param name="baseToken"></param>
+        /// <param name="quoteToken"></param>
+        public static void PauseOrderBook(UInt160 baseToken, UInt160 quoteToken)
+        {
+            Assert(baseToken.IsAddress() && quoteToken.IsAddress(), "Invalid Address");
+            Assert(Verify(), "No Authorization");
+
+            var pairKey = GetPairKey(baseToken, quoteToken);
+            var book = GetOrderBook(pairKey);
+            Assert(book.baseToken == baseToken && book.quoteToken == quoteToken, "Invalid Trade Pair");
+            Assert(!BookPaused(pairKey), "Book Already Paused");
+
+            SetPaused(pairKey);
+            onBookStatusChanged(book.baseToken, book.quoteToken, book.quoteScale, book.minOrderAmount, book.maxOrderAmount, BookPaused(pairKey));
+        }
+
+        /// <summary>
+        /// Resume a paused order book
+        /// </summary>
+        /// <param name="baseToken"></param>
+        /// <param name="quoteToken"></param>
+        public static void ResumeOrderBook(UInt160 baseToken, UInt160 quoteToken)
+        {
+            Assert(baseToken.IsAddress() && quoteToken.IsAddress(), "Invalid Address");
+            Assert(Verify(), "No Authorization");
+
+            var pairKey = GetPairKey(baseToken, quoteToken);
+            var book = GetOrderBook(pairKey);
+            Assert(book.baseToken == baseToken && book.quoteToken == quoteToken, "Invalid Trade Pair");
+            Assert(BookPaused(pairKey), "Book Not Paused");
+
+            RemovePaused(pairKey);
+            onBookStatusChanged(book.baseToken, book.quoteToken, book.quoteScale, book.minOrderAmount, book.maxOrderAmount, BookPaused(pairKey));
+        }
+
+        /// <summary>
+        /// Add a new order into orderbook but try deal it first
+        /// </summary>
+        /// <param name="tokenA"></param>
+        /// <param name="tokenB"></param>
+        /// <param name="maker"></param>
+        /// <param name="isBuy"></param>
+        /// <param name="price"></param>
+        /// <param name="amount"></param>
+        /// <returns>Null or a new order id</returns>
+        public static ByteString AddLimitOrder(UInt160 tokenA, UInt160 tokenB, UInt160 maker, bool isBuy, BigInteger price, BigInteger amount)
+        {
+            // Check parameters
+            Assert(price > 0 && amount > 0, "Invalid Parameters");
+            var pairKey = GetPairKey(tokenA, tokenB);
+            Assert(!BookPaused(pairKey), "Book is Paused");
+            Assert(Runtime.CheckWitness(maker), "No Authorization");
+            Assert(ContractManagement.GetContract(maker) == null, "Forbidden");
+
+            // Deposit token
+            var book = GetOrderBook(pairKey);
+            if (amount < book.minOrderAmount || amount > book.maxOrderAmount) return null;
+            var me = Runtime.ExecutingScriptHash;
+            if (isBuy) SafeTransfer(book.quoteToken, maker, me, amount * price / book.quoteScale);
+            else SafeTransfer(book.baseToken, maker, me, amount);
+
+            // Do add
+            var id = GetUnusedID();
+            Assert(InsertOrder(pairKey, book, id, new LimitOrder(){
+                maker = maker,
+                price = price,
+                amount = amount
+            }, isBuy), "Add Order Fail");
+
+            // Add receipt
+            SetReceipt(maker, id, new OrderReceipt(){
+                baseToken = book.baseToken,
+                quoteToken = book.quoteToken,
+                id = id,
+                time = Runtime.Time,
+                isBuy = isBuy,
+                totalAmount = amount
+            });
+            onOrderStatusChanged(book.baseToken, book.quoteToken, id, !!isBuy, maker, price, amount);
+            return id;
+        }
+
+        /// <summary>
+        /// Add a new order into orderbook with an expected parent order id
+        /// </summary>
+        /// <param name="parentID"></param>
+        /// <param name="maker"></param>
+        /// <param name="price"></param>
+        /// <param name="amount"></param>
+        /// <returns>Null or a new order id</returns>
+        public static ByteString AddLimitOrderAt(ByteString parentID, UInt160 maker, BigInteger price, BigInteger amount)
+        {
+            // Check parameters
+            Assert(price > 0 && amount > 0, "Invalid Parameters");
+            var receipt = GetReceipt(GetOrder(parentID).maker, parentID);
+            var pairKey = GetPairKey(receipt.baseToken, receipt.quoteToken);
+            Assert(!BookPaused(pairKey), "Book is Paused");
+            Assert(Runtime.CheckWitness(maker), "No Authorization");
+            Assert(ContractManagement.GetContract(maker) == null, "Forbidden");
+
+            // Check amount
+            var book = GetOrderBook(pairKey);
+            Assert(amount >= book.minOrderAmount && amount <= book.maxOrderAmount, "Invalid Limit Order Amount");
+
+            // Deposit token
+            var me = Runtime.ExecutingScriptHash;
+            if (receipt.isBuy) SafeTransfer(receipt.quoteToken, maker, me, amount * price / book.quoteScale);
+            else SafeTransfer(receipt.baseToken, maker, me, amount);
+
+            // Insert new order
+            var id = GetUnusedID();
+            Assert(InsertOrderAt(parentID, id, new LimitOrder(){
+                maker = maker,
+                price = price,
+                amount = amount
+            }, receipt.isBuy), "Add Order Fail");
+
+            // Add receipt
+            SetReceipt(maker, id, new OrderReceipt(){
+                baseToken = receipt.baseToken,
+                quoteToken = receipt.quoteToken,
+                id = id,
+                time = Runtime.Time,
+                isBuy = receipt.isBuy,
+                totalAmount = amount
+            });
+            onOrderStatusChanged(receipt.baseToken, receipt.quoteToken, id, !!receipt.isBuy, maker, price, amount);
+            return id;
+        }
+
+        /// <summary>
+        /// Cancel a limit order with its id
+        /// </summary>
+        /// <param name="tokenA"></param>
+        /// <param name="tokenB"></param>
+        /// <param name="isBuy"></param>
+        /// <param name="id"></param>
+        public static void CancelOrder(UInt160 tokenA, UInt160 tokenB, bool isBuy, ByteString id)
+        {
+            // Check if exist
+            var pairKey = GetPairKey(tokenA, tokenB);
+            Assert(OrderExists(id), "Order Not Exists");
+            var order = GetOrder(id);
+            Assert(Runtime.CheckWitness(order.maker), "No Authorization");
+
+            // Do remove
+            var book = GetOrderBook(pairKey);
+            Assert(RemoveOrder(pairKey, book, id, isBuy), "Remove Order Fail");
+
+            // Remove receipt
+            DeleteReceipt(order.maker, id);
+            onOrderStatusChanged(book.baseToken, book.quoteToken, id, !!isBuy, order.maker, order.price, 0);
+
+            // Withdraw token
+            var me = Runtime.ExecutingScriptHash;
+            if (isBuy) SafeTransfer(book.quoteToken, me, order.maker, order.amount * order.price / book.quoteScale);
+            else SafeTransfer(book.baseToken, me, order.maker, order.amount);
+        }
+
+        /// <summary>
+        /// Cancel a limit order with its id and parent order id
+        /// </summary>
+        /// <param name="parentID"></param>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        public static bool CancelOrderAt(ByteString parentID, ByteString id)
+        {
+            if (!OrderExists(id)) return false;
+            Assert(OrderExists(parentID), "Parent Order Not Exists");
+            var order = GetOrder(id);
+            Assert(Runtime.CheckWitness(order.maker), "No Authorization");
+
+            // Do remove
+            var receipt = GetReceipt(order.maker, id);
+            var pairKey = GetPairKey(receipt.baseToken, receipt.quoteToken);
+            var book = GetOrderBook(pairKey);
+
+            Assert(RemoveOrderAt(parentID, id), "Remove Order Fail");
+
+            // Remove receipt
+            DeleteReceipt(order.maker, id);
+            onOrderStatusChanged(receipt.baseToken, receipt.quoteToken, id, !!receipt.isBuy, order.maker, order.price, 0);
+
+            // Withdraw token
+            var me = Runtime.ExecutingScriptHash;
+            if (receipt.isBuy) SafeTransfer(receipt.quoteToken, me, order.maker, order.amount * order.price / book.quoteScale);
+            else SafeTransfer(receipt.baseToken, me, order.maker, order.amount);
+            return true;
+        }
+
+        /// <summary>
+        /// Try get the parent order id of an existing order
+        /// </summary>
+        /// <param name="tokenA"></param>
+        /// <param name="tokenB"></param>
+        /// <param name="isBuy"></param>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        [Safe]
+        public static ByteString GetParentOrderID(UInt160 tokenA, UInt160 tokenB, bool isBuy, ByteString id)
+        {
+            var pairKey = GetPairKey(tokenA, tokenB);
+            return GetParentID(pairKey, isBuy, id);
+        }
+
+        /// <summary>
+        /// Get first N limit orders and their details
+        /// </summary>
+        /// <param name="tokenA"></param>
+        /// <param name="tokenB"></param>
+        /// <param name="isBuy"></param>
+        /// <param name="pos"></param>
+        /// <param name="n"></param>
+        /// <returns></returns>
+        [Safe]
+        public static OrderReceipt[] GetNOrders(UInt160 tokenA, UInt160 tokenB, bool isBuy, uint pos, uint n)
+        {
+            var results = new OrderReceipt[n];
+
+            var pairKey = GetPairKey(tokenA, tokenB);
+            var book = GetOrderBook(pairKey);
+            var firstID = isBuy ? book.firstBuyID : book.firstSellID;
+            if (firstID is null) return results;
+
+            var currentOrderID = firstID;
+            var currentOrder = GetOrder(currentOrderID);
+            for (int i = 0; i < pos + n; i++)
+            {
+                if (i >= pos)
+                {
+                    var receipt = GetReceipt(currentOrder.maker, currentOrderID);
+                    receipt.maker = currentOrder.maker;
+                    receipt.price = currentOrder.price;
+                    receipt.leftAmount = currentOrder.amount;
+                    results[i - pos] = receipt;
+
+                    if (currentOrder.nextID is null) break;
+                }
+                currentOrderID = currentOrder.nextID;
+                currentOrder = GetOrder(currentOrder.nextID);
+            }
+
+            return results;
+        }
+
+        /// <summary>
+        /// Get all orders and their details of maker
+        /// </summary>
+        /// <param name="maker"></param>
+        /// <param name="pos"></param>
+        /// <param name="n"></param>
+        /// <returns></returns>
+        [Safe]
+        public static OrderReceipt[] GetOrdersOf(UInt160 maker, uint pos, uint n)
+        {
+            var results = new OrderReceipt[n];
+            var iterator = ReceiptsOf(maker);
+            // Makeup details
+            for (int i = 0; i < pos + n; i++)
+            {
+                if (iterator.Next() && i >= pos)
+                {
+                    results[i - pos] = (OrderReceipt)iterator.Value;
+                    var order = GetOrder(results[i - pos].id);
+                    results[i - pos].maker = order.maker;
+                    results[i - pos].price = order.price;
+                    results[i - pos].leftAmount = order.amount;
+                }
+            }
+            return results;
+        }
+
+        /// <summary>
+        /// Get the total reverse of tradable orders with an expected price
+        /// </summary>
+        /// <param name="tokenA"></param>
+        /// <param name="tokenB"></param>
+        /// <param name="isBuy"></param>
+        /// <param name="price"></param>
+        /// <returns></returns>
+        [Safe]
+        public static BigInteger GetTotalTradable(UInt160 tokenA, UInt160 tokenB, bool isBuy, BigInteger price)
+        {
+            var pairKey = GetPairKey(tokenA, tokenB);
+            if (BookPaused(pairKey)) return 0;
+            return GetTotalTradableInternal(pairKey, isBuy, price);
+        }
+
+        private static BigInteger GetTotalTradableInternal(byte[] pairKey, bool isBuy, BigInteger price)
+        {
+            var totalTradable = BigInteger.Zero;
+            var book = GetOrderBook(pairKey);
+            var currentID = isBuy ? book.firstSellID : book.firstBuyID;
+            if (currentID is null) return totalTradable;
+            while (currentID is not null)
+            {
+                var currentOrder = GetOrder(currentID);
+                if ((isBuy && currentOrder.price > price) || (!isBuy && currentOrder.price < price)) break;
+                totalTradable += currentOrder.amount;
+                currentID = currentOrder.nextID;
+            }
+            return totalTradable;
+        }
+
+        /// <summary>
+        /// Try to match without real payment
+        /// </summary>
+        /// <param name="tokenA"></param>
+        /// <param name="tokenB"></param>
+        /// <param name="isBuy"></param>
+        /// <param name="price"></param>
+        /// <param name="amount"></param>
+        /// <returns></returns>
+        [Safe]
+        public static BigInteger[] MatchOrder(UInt160 tokenA, UInt160 tokenB, bool isBuy, BigInteger price, BigInteger amount)
+        {
+            // Check if exist
+            var pairKey = GetPairKey(tokenA, tokenB);
+            if (BookPaused(pairKey)) return new BigInteger[] { amount, 0 };
+            return MatchOrderInternal(pairKey, isBuy, price, amount);
+        }
+
+        private static BigInteger[] MatchOrderInternal(byte[] pairKey, bool isBuy, BigInteger price, BigInteger amount)
+        {
+            var totalPayment = BigInteger.Zero;
+            var book = GetOrderBook(pairKey);
+            var currentID = isBuy ? book.firstSellID : book.firstBuyID;
+            if (currentID is null) return new BigInteger[] { amount, 0 };
+            var currentOrder = GetOrder(currentID);
+
+            while (amount > 0)
+            {
+                // Check price
+                if ((isBuy && currentOrder.price > price) || (!isBuy && currentOrder.price < price)) break;
+
+                if (currentOrder.amount <= amount) 
+                {
+                    totalPayment += currentOrder.amount * currentOrder.price / book.quoteScale;
+                    amount -= currentOrder.amount;
+                }
+                else
+                {
+                    totalPayment += amount * currentOrder.price / book.quoteScale;
+                    amount = 0;
+                }
+
+                if (currentOrder.nextID is null) break;
+                currentOrder = GetOrder(currentOrder.nextID);
+            }
+
+            // A least payment for buyer
+            if (isBuy && totalPayment == 0) totalPayment += 1;
+            return new BigInteger[] { amount, totalPayment };
+        }
+
+        /// <summary>
+        /// Try to match without real payment
+        /// </summary>
+        /// <param name="tokenA"></param>
+        /// <param name="tokenB"></param>
+        /// <param name="isBuy"></param>
+        /// <param name="price"></param>
+        /// <param name="quoteAmount"></param>
+        /// <returns>Left amount and tradable base</returns>
+        [Safe]
+        public static BigInteger[] MatchQuote(UInt160 tokenA, UInt160 tokenB, bool isBuy, BigInteger price, BigInteger quoteAmount)
+        {
+            var pairKey = GetPairKey(tokenA, tokenB);
+            if (BookPaused(pairKey)) return new BigInteger[] { quoteAmount, 0 };
+            return MatchQuoteInternal(pairKey, isBuy, price, quoteAmount);
+        }
+
+        private static BigInteger[] MatchQuoteInternal(byte[] pairKey, bool isBuy, BigInteger price, BigInteger quoteAmount)
+        {
+            var totalTradable = BigInteger.Zero;
+            var book = GetOrderBook(pairKey);
+            var currentID = isBuy ? book.firstSellID : book.firstBuyID;
+            if (currentID is null) return new BigInteger[] { quoteAmount, 0 };
+            var currentOrder = GetOrder(currentID);
+
+            while (quoteAmount > 0)
+            {
+                // Check price
+                if ((isBuy && currentOrder.price > price) || (!isBuy && currentOrder.price < price)) break;
+                var payment = currentOrder.amount * currentOrder.price / book.quoteScale;
+                if (payment <= quoteAmount) 
+                {
+                    totalTradable += currentOrder.amount;
+                    quoteAmount -= payment;
+                }
+                else
+                {
+                    // For buyer, real payment <= expected
+                    if (isBuy) totalTradable += quoteAmount * book.quoteScale / currentOrder.price;
+                    // For seller, real payment >= expected
+                    else totalTradable += (quoteAmount * book.quoteScale + currentOrder.price - 1) / currentOrder.price;
+                    quoteAmount = 0;
+                }
+
+                if (currentOrder.nextID is null) break;
+                currentOrder = GetOrder(currentOrder.nextID);
+            }
+            return new BigInteger[] { quoteAmount, totalTradable };
+        }
+
+        /// <summary>
+        /// Try to make a market deal with orderbook
+        /// </summary>
+        /// <param name="tokenA"></param>
+        /// <param name="tokenB"></param>
+        /// <param name="taker"></param>
+        /// <param name="isBuy"></param>
+        /// <param name="price"></param>
+        /// <param name="amount"></param>
+        /// <returns>Left amount</returns>
+        public static BigInteger DealMarketOrder(UInt160 tokenA, UInt160 tokenB, UInt160 taker, bool isBuy, BigInteger price, BigInteger amount)
+        {
+            // Check parameters
+            Assert(price > 0 && amount > 0, "Invalid Parameters");
+            var pairKey = GetPairKey(tokenA, tokenB);
+            Assert(!BookPaused(pairKey), "Book is Paused");
+            Assert(Runtime.CheckWitness(taker), "No Authorization");
+            Assert(ContractManagement.GetContract(taker) == null, "Forbidden");
+
+            return DealMarketOrderInternal(pairKey, taker, isBuy, price, amount, false);
+        }
+
+        public static BigInteger DealMarketOrder(UInt160 tokenA, UInt160 tokenB, bool isBuy, BigInteger price, BigInteger amount)
+        {
+            // Check parameters
+            Assert(price > 0 && amount > 0, "Invalid Parameters");
+            var pairKey = GetPairKey(tokenA, tokenB);
+            Assert(!BookPaused(pairKey), "Book is Paused");
+            var caller = Runtime.CallingScriptHash;
+            Assert(ContractManagement.GetContract(caller) != null, "Forbidden"); 
+
+            return DealMarketOrderInternal(pairKey, caller, isBuy, price, amount, true);
+        }
+
+        private static BigInteger DealMarketOrderInternal(byte[] pairKey, UInt160 taker, bool isBuy, BigInteger price, BigInteger leftAmount, bool shouldRequest)
+        {
+            // Check if can deal
+            var book = GetOrderBook(pairKey);
+            var firstID = isBuy ? book.firstSellID : book.firstBuyID;
+            if (firstID is null) return leftAmount;
+            var firstOrder = GetOrder(firstID);
+            var canDeal = (isBuy && firstOrder.price <= price) || (!isBuy && firstOrder.price >= price);
+            if (!canDeal) return leftAmount;
+
+            var me = Runtime.ExecutingScriptHash;
+            var fundAddress = GetFundAddress();
+
+            var quoteFee = BigInteger.Zero;
+            var baseFee = BigInteger.Zero;
+
+            var takerReceive = BigInteger.Zero;
+            var takerPayment = BigInteger.Zero;
+            var makerReceive = new Map<UInt160, BigInteger>();
+
+            var currentID = firstID;
+            while (currentID is not null)
+            {
+                var currentOrder = GetOrder(currentID);
+                if ((isBuy && currentOrder.price > price) || (!isBuy && currentOrder.price < price)) break;
+
+                BigInteger quoteAmount;
+                BigInteger baseAmount;
+                BigInteger quotePayment;
+                BigInteger basePayment;
+
+                if (currentOrder.amount <= leftAmount)
+                {
+                    // Full-fill
+                    quoteAmount = currentOrder.amount * currentOrder.price / book.quoteScale;
+                    baseAmount = currentOrder.amount;
+
+                    // Remove full-fill order
+                    DeleteOrder(currentID);
+                    DeleteReceipt(currentOrder.maker, currentID);
+                    firstID = currentOrder.nextID;
+
+                    onOrderStatusChanged(book.baseToken, book.quoteToken, currentID, !isBuy, currentOrder.maker, currentOrder.price, 0);
+                    leftAmount -= currentOrder.amount;
+                }
+                else
+                {
+                    // Part-fill
+                    quoteAmount = leftAmount * currentOrder.price / book.quoteScale;
+                    baseAmount = leftAmount;
+
+                    // Update order
+                    currentOrder.amount -= leftAmount;
+                    SetOrder(currentID, currentOrder);
+
+                    onOrderStatusChanged(book.baseToken, book.quoteToken, currentID, !isBuy, currentOrder.maker, currentOrder.price, currentOrder.amount);
+                    leftAmount = 0;
+                }
+
+                // Record payment
+                quotePayment = quoteAmount * 997 / 1000;
+                basePayment = baseAmount * 997 / 1000;
+                quoteFee += quoteAmount - quotePayment;
+                baseFee += baseAmount - basePayment;
+
+                if (isBuy)
+                {
+                    takerPayment += quoteAmount;
+                    takerReceive += basePayment;
+                    if (makerReceive.HasKey(currentOrder.maker)) makerReceive[currentOrder.maker] += quotePayment;
+                    else makerReceive[currentOrder.maker] = quotePayment;
+                }
+                else
+                {
+                    takerPayment += baseAmount;
+                    takerReceive += quotePayment;
+                    if (makerReceive.HasKey(taker)) makerReceive[taker] += basePayment;
+                    else makerReceive[taker] = basePayment;
+                }
+
+                // Check if still tradable
+                if (leftAmount == 0) break;
+                currentID = currentOrder.nextID;
+            }
+
+            // Update book if necessary
+            if (isBuy && book.firstSellID != firstID)
+            {
+                book.firstSellID = firstID;
+                SetOrderBook(pairKey, book);
+            }
+            if (!isBuy && book.firstBuyID != firstID)
+            {
+                book.firstBuyID = firstID;
+                SetOrderBook(pairKey, book);
+            }
+
+            // Do transfer
+            if (takerPayment == 0) takerPayment += 1;
+            if (isBuy)
+            {
+                if (shouldRequest) RequestTransfer(book.quoteToken, taker, me, takerPayment);
+                else SafeTransfer(book.quoteToken, taker, me, takerPayment);
+                SafeTransfer(book.baseToken, me, taker, takerReceive);
+                foreach (var toAddress in makerReceive.Keys) SafeTransfer(book.quoteToken, me, toAddress, makerReceive[toAddress]);
+            }
+            else
+            {
+                if (shouldRequest) RequestTransfer(book.baseToken, taker, me, takerPayment);
+                else SafeTransfer(book.baseToken, taker, me, takerPayment);
+                SafeTransfer(book.quoteToken, me, taker, takerReceive);
+                foreach (var toAddress in makerReceive.Keys) SafeTransfer(book.baseToken, me, toAddress, makerReceive[toAddress]);
+            }
+            
+
+            if (fundAddress is not null)
+            {
+                SafeTransfer(book.quoteToken, me, fundAddress, quoteFee);
+                SafeTransfer(book.baseToken, me, fundAddress, baseFee);
+            }
+            return leftAmount;
+        }
+
+        /// <summary>
+        /// Deal a whole limit order with it id and parent id
+        /// </summary>
+        /// <param name="taker"></param>
+        /// <param name="parentID"></param>
+        /// <param name="id"></param>
+        public static void DealMarketOrderAt(UInt160 taker, ByteString parentID, ByteString id)
+        {
+            Assert(Runtime.CheckWitness(taker), "No Authorization");
+            
+            // Do deal
+            var order = GetOrder(id);
+            var me = Runtime.ExecutingScriptHash;
+            var receipt = GetReceipt(order.maker, id);
+            var pairKey = GetPairKey(receipt.baseToken, receipt.quoteToken);
+            Assert(!BookPaused(pairKey), "Book is Paused");
+            var quoteScale = GetOrderBook(pairKey).quoteScale;
+            var fundAddress = GetFundAddress();
+
+            var baseAmount = order.amount;
+            var quoteAmount = order.amount * order.price / quoteScale;
+            var basePayment = baseAmount * 997 / 1000;
+            var quotePayment = quoteAmount * 997 / 1000;
+            var baseFee = baseAmount - basePayment;
+            var quoteFee = quoteAmount - quotePayment;
+
+            if (receipt.isBuy) SafeTransfer(receipt.baseToken, taker, me, baseAmount);
+            else SafeTransfer(receipt.quoteToken, taker, me, quoteAmount);
+
+            // Remove order and receipt
+            Assert(RemoveOrderAt(parentID, id), "Remove Order Fail");
+            DeleteReceipt(order.maker, id);
+            onOrderStatusChanged(receipt.baseToken, receipt.quoteToken, id, !!receipt.isBuy, order.maker, order.price, 0);
+
+            // Transfer
+            if (receipt.isBuy)
+            {
+                SafeTransfer(receipt.baseToken, me, order.maker, basePayment);
+                SafeTransfer(receipt.quoteToken, me, taker, quotePayment);
+            }
+            else
+            {
+                SafeTransfer(receipt.baseToken, me, taker, basePayment);
+                SafeTransfer(receipt.quoteToken, me, order.maker, quotePayment);
+            }
+
+            if (fundAddress is not null)
+            {
+                SafeTransfer(receipt.baseToken, me, fundAddress, baseFee);
+                SafeTransfer(receipt.quoteToken, me, fundAddress, quoteFee);
+            }
+        }
+
+        /// <summary>
+        /// Price reporter
+        /// </summary>
+        /// <param name="tokenA"></param>
+        /// <param name="tokenB"></param>
+        /// <param name="isBuy"></param>
+        /// <returns></returns>
+        [Safe]
+        public static BigInteger GetMarketPrice(UInt160 tokenA, UInt160 tokenB, bool isBuy)
+        {
+            var pairKey = GetPairKey(tokenA, tokenB);
+            var book = GetOrderBook(pairKey);
+            var firstID = isBuy ? book.firstSellID : book.firstBuyID;
+            if (firstID is null) return 0;
+            return GetOrder(firstID).price;
+        }
+
+        [Safe]
+        public static OrderBook GetBookInfo(UInt160 tokenA, UInt160 tokenB)
+        {
+            var pairKey = GetPairKey(tokenA, tokenB);
+            return GetOrderBook(pairKey);
+        }
+        #endregion
+
+        #region AMM like API
+        /// <summary>
+        /// Calculate amountOut with amountIn
+        /// </summary>
+        /// <param name="tokenFrom"></param>
+        /// <param name="tokenTo"></param>
+        /// <param name="price"></param>
+        /// <param name="amountIn"></param>
+        /// <returns>Unsatisfied amountIn and amountOut</returns>
+        [Safe]
+        public static BigInteger[] GetAmountOut(UInt160 tokenFrom, UInt160 tokenTo, BigInteger price, BigInteger amountIn)
+        {
+            // Check if exist
+            var pairKey = GetPairKey(tokenFrom, tokenTo);
+            if (BookPaused(pairKey)) return new BigInteger[] { amountIn, 0 };
+            var book = GetOrderBook(pairKey);
+            var isBuy = tokenFrom == book.quoteToken;
+            if (isBuy)
+            {
+                var result = MatchQuoteInternal(pairKey, isBuy, price, amountIn);
+                return new BigInteger[]{ result[0], result[1] * 997 / 1000 };   // 0.3% fee
+            }
+            else
+            {
+                var result = MatchOrderInternal(pairKey, isBuy, price, amountIn);
+                return new BigInteger[]{ result[0], result[1] * 997 / 1000 };   // 0.3% fee
+            }
+        }
+
+        /// <summary>
+        /// Calculate amountOut with amountIn
+        /// </summary>
+        /// <param name="tokenFrom"></param>
+        /// <param name="tokenTo"></param>
+        /// <param name="price"></param>
+        /// <param name="amountOut"></param>
+        /// <returns>Unsatisfied amountOut and amountIn</returns>
+        [Safe]
+        public static BigInteger[] GetAmountIn(UInt160 tokenFrom, UInt160 tokenTo, BigInteger price, BigInteger amountOut)
+        {
+            // Check if exist
+            var pairKey = GetPairKey(tokenFrom, tokenTo);
+            if (BookPaused(pairKey)) return new BigInteger[] { amountOut, 0 };
+            var book = GetOrderBook(pairKey);
+            var isBuy = tokenFrom == book.quoteToken;
+            if (isBuy)
+            {
+                var result = MatchOrderInternal(pairKey, isBuy, price, (amountOut * 1000 + 996) / 997);   // 0.3% fee
+                return new BigInteger[]{ result[0] * 997 / 1000, result[1] };
+            }
+            else
+            {
+                var result = MatchQuoteInternal(pairKey, isBuy, price, (amountOut * 1000 + 996) / 997);   // 0.3% fee
+                return new BigInteger[]{ (result[0] * 997 + 999) / 1000, result[1] };
+            }
+        }
+        #endregion
+
+        /// <summary>
+        /// Accept NEP-17 token
+        /// SwapTokenInForTokenOut
+        /// </summary>
+        /// <param name="from"></param>
+        /// <param name="amount"></param>
+        /// <param name="data"></param>
+        public static void OnNEP17Payment(UInt160 from, BigInteger amount, object data)
+        {
+
+        }
+
+        /// <summary>
+        /// Calculate amountIn to reach AMM price
+        /// </summary>
+        /// <param name="isBuy"></param>
+        /// <param name="price"></param>
+        /// <param name="quoteScale"></param>
+        /// <param name="reserveIn"></param>
+        /// <param name="reserveOut"></param>
+        private static BigInteger GetAmountInTillPrice(bool isBuy, BigInteger price, BigInteger quoteScale, BigInteger reserveIn, BigInteger reserveOut)
+        {
+            Assert(price > 0 && quoteScale > 0 && reserveIn > 0 && reserveOut > 0, "Parameter Invalid");
+            var amountIn = BigInteger.Pow(reserveIn, 2) * 9000000;
+            if (isBuy) amountIn += reserveIn * reserveOut * price * 3988000000000 / quoteScale;
+            else amountIn += reserveIn * reserveOut * quoteScale * 3988000000000 / price;
+            return (amountIn.Sqrt() - reserveIn * 1997000) / 1994000;
+        }
+
+        private static BigInteger GetAmountInTillPriceWithFundFee(bool isBuy, BigInteger price, BigInteger quoteScale, BigInteger reserveIn, BigInteger reserveOut)
+        {
+            Assert(price > 0 && quoteScale > 0 && reserveIn > 0 && reserveOut > 0, "Parameter Invalid");
+            var amountIn = BigInteger.Pow(reserveIn, 2) * 6250000;
+            if (isBuy) amountIn += reserveIn * reserveOut * price * 3986006000000 / quoteScale;
+            else amountIn += reserveIn * reserveOut * quoteScale * 3986006000000 / price;
+            return (amountIn.Sqrt() - reserveIn * 1996500) / 1993003;
+        }
+
+        /// <summary>
+        /// AMM GetAmountOut
+        /// </summary>
+        /// <param name="amountIn"></param>
+        /// <param name="reserveIn"></param>
+        /// <param name="reserveOut"></param>
+        /// <returns></returns>
+        private static BigInteger GetAmountOut(BigInteger amountIn, BigInteger reserveIn, BigInteger reserveOut)
+        {
+            Assert(amountIn >= 0 && reserveIn > 0 && reserveOut > 0, "AmountIn Must >= 0");
+            var amountInWithFee = amountIn * 997;
+            var numerator = amountInWithFee * reserveOut;
+            var denominator = reserveIn * 1000 + amountInWithFee;
+            var amountOut = numerator / denominator;
+            return amountOut;
+        }
+
+        /// <summary>
+        /// AMM GetAmountIn
+        /// </summary>
+        /// <param name="amountOut"></param>
+        /// <param name="reserveIn"></param>
+        /// <param name="reserveOut"></param>
+        /// <returns></returns>
+        private static BigInteger GetAmountIn(BigInteger amountOut, BigInteger reserveIn, BigInteger reserveOut)
+        {
+            Assert(amountOut >= 0 && reserveIn > 0 && reserveOut > 0, "AmountOut Must >= 0");
+            var numerator = reserveIn * amountOut * 1000;
+            var denominator = (reserveOut - amountOut) * 997;
+            var amountIn = (numerator / denominator) + 1;
+            return amountIn;
+        }
+
+        /// <summary>
+        /// Swap as a router
+        /// </summary>
+        /// <param name="pairContract"></param>
+        /// <param name="sender"></param>
+        /// <param name="tokenIn"></param>
+        /// <param name="tokenOut"></param>
+        /// <param name="amountIn"></param>
+        /// <param name="amountOut"></param>
+        private static void SwapAMM(UInt160 pairContract, UInt160 sender, UInt160 tokenIn, UInt160 tokenOut, BigInteger amountIn, BigInteger amountOut)
+        {
+            SafeTransfer(tokenIn, sender, pairContract, amountIn);
+
+            BigInteger amount0Out = 0;
+            BigInteger amount1Out = 0;
+            if (tokenIn.ToUInteger() < tokenOut.ToUInteger()) amount1Out = amountOut;
+            else amount0Out = amountOut;
+
+            SwapOut(pairContract, amount0Out, amount1Out, sender);
+        }
+    }
+}

--- a/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBookContract.cs
+++ b/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBookContract.cs
@@ -22,9 +22,9 @@ namespace FlamingoSwapOrderBook
         /// <param name="tokenB"></param>
         /// <param name="sender"></param>
         /// <param name="isBuy"></param>
-        /// <param name="amount">Total buy(real get)/sell amount of the limit order</param>
+        /// <param name="amount">Total buy/sell(real get/pay) amount of the limit order</param>
         /// <param name="price">Price limit of the order</param>
-        /// <param name="bookAmount">Expected amount to buy(real get)/sell from/to book before amm</param>
+        /// <param name="bookAmount">Expected amount to buy/sell(in-book amount) in book before amm</param>
         /// <param name="bookPrice">Price limit of bookAmount part</param>
         /// <param name="deadLine"></param>
         /// <returns></returns>
@@ -40,7 +40,7 @@ namespace FlamingoSwapOrderBook
 
             // Market order
             var leftAmount = amount;
-            if (isBuy) leftAmount -= bookAmount > 0 ? bookAmount - DealMarketOrderInternal(pairKey, sender, isBuy, bookPrice, (bookAmount * 1000 + 996) / 997, false) * 997 / 1000 : 0;
+            if (isBuy) leftAmount -= bookAmount > 0 ? (bookAmount - DealMarketOrderInternal(pairKey, sender, isBuy, bookPrice, bookAmount, false)) * 997 / 1000 : 0;
             else leftAmount -= bookAmount > 0 ? bookAmount - DealMarketOrderInternal(pairKey, sender, isBuy, bookPrice, bookAmount, false) : 0;
             if (leftAmount == 0) return null;
 
@@ -109,9 +109,9 @@ namespace FlamingoSwapOrderBook
         /// <param name="tokenB"></param>
         /// <param name="sender"></param>
         /// <param name="isBuy"></param>
-        /// <param name="amount">Total buy(real get)/sell amount of the limit order</param>
-        /// <param name="slippage">The amount limit of final payment/receive(real get)</param>
-        /// <param name="bookAmount">Expected amount to buy(real get)/sell from/to book before amm</param>
+        /// <param name="amount">Total buy/sell(real get/pay) amount of the limit order</param>
+        /// <param name="slippage">The amount limit of final receive/payment(real get/pay)</param>
+        /// <param name="bookAmount">Expected amount to buy/sell(in-book amount) in book before amm</param>
         /// <param name="bookPrice">Price limit of bookAmount part</param>
         /// <param name="deadLine"></param>
         /// <returns></returns>
@@ -133,7 +133,7 @@ namespace FlamingoSwapOrderBook
             if (bookAmount > 0)
             {
                 var balanceBefore = GetBalanceOf(book.quoteToken, sender);
-                if (isBuy) amount -= bookAmount - DealMarketOrderInternal(pairKey, sender, isBuy, bookPrice, (bookAmount * 1000 + 996) / 997, false) * 997 / 1000;
+                if (isBuy) amount -= (bookAmount - DealMarketOrderInternal(pairKey, sender, isBuy, bookPrice, bookAmount, false)) * 997 / 1000;
                 else amount -= bookAmount - DealMarketOrderInternal(pairKey, sender, isBuy, bookPrice, bookAmount, false);
                 var balanceAfter = GetBalanceOf(book.quoteToken, sender);
                 quoteAmount = isBuy ? balanceBefore - balanceAfter : balanceAfter - balanceBefore;

--- a/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBookContract.cs
+++ b/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBookContract.cs
@@ -35,7 +35,9 @@ namespace FlamingoSwapOrderBook
             Assert(ContractManagement.GetContract(sender) == null, "Forbidden");
 
             // Market order
-            var leftAmount = expectBookAmount > 0 ? amount - expectBookAmount + DealMarketOrderInternal(pairKey, sender, isBuy, price, expectBookAmount, false) : amount;
+            var leftAmount = amount;
+            if (isBuy) leftAmount -= expectBookAmount > 0 ? expectBookAmount - DealMarketOrderInternal(pairKey, sender, isBuy, price, (expectBookAmount * 1000 + 996) / 997, false) * 997 / 1000 : 0;
+            else leftAmount -= expectBookAmount > 0 ? expectBookAmount - DealMarketOrderInternal(pairKey, sender, isBuy, price, expectBookAmount, false) : 0;
             if (leftAmount == 0) return null;
 
             // Swap AMM
@@ -120,8 +122,10 @@ namespace FlamingoSwapOrderBook
             Assert(book.baseToken.IsAddress() && book.quoteToken.IsAddress(), "Invalid Trade Pair");
             var price = slippage * book.quoteScale / amount;
 
+            var leftAmount = amount;
             var balanceBefore = GetBalanceOf(book.quoteToken, sender);
-            var leftAmount = expectBookAmount > 0 ? amount - expectBookAmount + DealMarketOrderInternal(pairKey, sender, isBuy, price, expectBookAmount, false) : amount;
+            if (isBuy) leftAmount -= expectBookAmount > 0 ? expectBookAmount - DealMarketOrderInternal(pairKey, sender, isBuy, price, (expectBookAmount * 1000 + 996) / 997, false) * 997 / 1000 : 0;
+            else leftAmount -= expectBookAmount > 0 ? expectBookAmount - DealMarketOrderInternal(pairKey, sender, isBuy, price, expectBookAmount, false) : 0;
             var balanceAfter = GetBalanceOf(book.quoteToken, sender);
             if (leftAmount == 0)
             {

--- a/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBookContract.cs
+++ b/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBookContract.cs
@@ -446,7 +446,7 @@ namespace FlamingoSwapOrderBook
         /// <param name="n"></param>
         /// <returns></returns>
         [Safe]
-        public static OrderReceipt[] GetNOrders(UInt160 tokenA, UInt160 tokenB, bool isBuy, uint pos, uint n)
+        public static OrderReceipt[] GetFirstNOrders(UInt160 tokenA, UInt160 tokenB, bool isBuy, uint pos, uint n)
         {
             var results = new OrderReceipt[n];
 

--- a/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBookContract.cs
+++ b/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBookContract.cs
@@ -1051,7 +1051,7 @@ namespace FlamingoSwapOrderBook
             var isBuy = tokenFrom == book.quoteToken;
 
             var result = MatchOrderInternal(pairKey, isBuy, price, (amountOut * 1000 + 996) / 997, isBuy);   // 0.3% fee
-            return new BigInteger[]{ isBuy ? result[0] * 997 / 1000 : (result[0] * 997 + 999) / 1000, result[1] };
+            return new BigInteger[]{ (result[0] * 997 + 999) / 1000, result[1] + 1 };
         }
         #endregion
 

--- a/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBookContract.cs
+++ b/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/FlamingoSwapOrderBookContract.cs
@@ -40,8 +40,8 @@ namespace FlamingoSwapOrderBook
 
             // Market order
             var leftAmount = amount;
-            if (isBuy) leftAmount -= bookAmount > 0 ? bookAmount - DealMarketOrderInternal(pairKey, sender, isBuy, bookPrice, (bookAmount * 1000 + 996) / 997, true, false)[0] * 997 / 1000 : 0;
-            else leftAmount -= bookAmount > 0 ? bookAmount - DealMarketOrderInternal(pairKey, sender, isBuy, bookPrice, bookAmount, true, false)[0] : 0;
+            if (isBuy) leftAmount -= bookAmount > 0 ? DealMarketOrderInternal(pairKey, sender, isBuy, bookPrice, (bookAmount * 1000 + 996) / 997, true, false)[1] : 0;
+            else leftAmount -= bookAmount > 0 ? DealMarketOrderInternal(pairKey, sender, isBuy, bookPrice, bookAmount, true, false)[0] : 0;
             if (leftAmount == 0) return null;
 
             // Swap AMM
@@ -781,10 +781,10 @@ namespace FlamingoSwapOrderBook
             var book = GetOrderBook(pairKey);
             Assert(book.baseToken.IsAddress() && book.quoteToken.IsAddress(), "Invalid Trade Pair");
             var firstID = isBuy ? book.firstSellID : book.firstBuyID;
-            if (firstID is null) return new BigInteger[] { amount, 0 };
+            if (firstID is null) return new BigInteger[] { 0, 0 };
             var firstOrder = GetOrder(firstID);
             var canDeal = (isBuy && firstOrder.price <= price) || (!isBuy && firstOrder.price >= price);
-            if (!canDeal) return new BigInteger[] { amount, 0 };
+            if (!canDeal) return new BigInteger[] { 0, 0 };
 
             var me = Runtime.ExecutingScriptHash;
             var fundAddress = GetFundAddress();

--- a/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/Models/LimitOrder.cs
+++ b/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/Models/LimitOrder.cs
@@ -1,0 +1,14 @@
+using Neo;
+using Neo.SmartContract.Framework;
+using System.Numerics;
+
+namespace FlamingoSwapOrderBook
+{
+    public struct LimitOrder
+    {
+        public UInt160 maker;
+        public BigInteger price;
+        public BigInteger amount;
+        public ByteString nextID;
+    }
+}

--- a/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/Models/OrderBook.cs
+++ b/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/Models/OrderBook.cs
@@ -1,0 +1,18 @@
+using Neo;
+using Neo.SmartContract.Framework;
+using System.Numerics;
+
+namespace FlamingoSwapOrderBook
+{
+    public struct OrderBook
+    {
+        public UInt160 baseToken;
+        public UInt160 quoteToken;
+        public BigInteger quoteScale;
+        public BigInteger minOrderAmount;
+        public BigInteger maxOrderAmount;
+
+        public ByteString firstBuyID;
+        public ByteString firstSellID;
+    }
+}

--- a/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/Models/OrderReceipt.cs
+++ b/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/Models/OrderReceipt.cs
@@ -1,0 +1,19 @@
+using Neo;
+using Neo.SmartContract.Framework;
+using System.Numerics;
+
+namespace FlamingoSwapOrderBook
+{
+    public struct OrderReceipt
+    {
+        public UInt160 baseToken;
+        public UInt160 quoteToken;
+        public ByteString id;
+        public ulong time;
+        public bool isBuy;
+        public UInt160 maker;
+        public BigInteger price;
+        public BigInteger totalAmount;
+        public BigInteger leftAmount;
+    }
+}

--- a/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/Models/ReservesData.cs
+++ b/Swap/flamingo-contract-swap/FlamingoSwapOrderBook/Models/ReservesData.cs
@@ -1,0 +1,10 @@
+using System.Numerics;
+
+namespace FlamingoSwapOrderBook
+{
+    public struct ReservesData
+    {
+        public BigInteger Reserve0;
+        public BigInteger Reserve1;
+    }
+}

--- a/Swap/flamingo-contract-swap/FlamingoSwapRouter/FlamingoSwapRouterContract.cs
+++ b/Swap/flamingo-contract-swap/FlamingoSwapRouter/FlamingoSwapRouterContract.cs
@@ -31,7 +31,7 @@ namespace FlamingoSwapRouter
         public static BigInteger[] AddLiquidity(UInt160 sender, UInt160 tokenA, UInt160 tokenB, BigInteger amountADesired, BigInteger amountBDesired, BigInteger amountAMin, BigInteger amountBMin, BigInteger deadLine)
         {
             //验证参数
-            Assert(sender.IsValid && tokenA.IsValid && tokenB.IsValid && amountADesired >= 0 && amountBDesired >= 0 && amountAMin >= 0 && amountBMin >= 0 && deadLine > 0, "Invalid Parameters");
+            Assert(amountADesired >= 0 && amountBDesired >= 0 && amountAMin >= 0 && amountBMin >= 0, "Invalid Parameters");
             //验证权限
             Assert(Runtime.CheckWitness(sender), "Forbidden");
             //看看有没有超过最后期限
@@ -80,7 +80,7 @@ namespace FlamingoSwapRouter
         public static BigInteger[] AddLiquidity(UInt160 tokenA, UInt160 tokenB, BigInteger amountADesired, BigInteger amountBDesired, BigInteger amountAMin, BigInteger amountBMin, BigInteger deadLine)
         {
             //验证参数
-            Assert(tokenA.IsValid && tokenB.IsValid && amountADesired >= 0 && amountBDesired >= 0 && amountAMin >= 0 && amountBMin >= 0 && deadLine > 0, "Invalid Parameters");
+            Assert(amountADesired >= 0 && amountBDesired >= 0 && amountAMin >= 0 && amountBMin >= 0, "Invalid Parameters");
             //验证权限
             var caller = Runtime.CallingScriptHash;
             Assert(ContractManagement.GetContract(caller) != null, "Forbidden");
@@ -142,7 +142,7 @@ namespace FlamingoSwapRouter
         public static BigInteger[] RemoveLiquidity(UInt160 sender, UInt160 tokenA, UInt160 tokenB, BigInteger liquidity, BigInteger amountAMin, BigInteger amountBMin, BigInteger deadLine)
         {
             //验证参数
-            Assert(sender.IsValid && tokenA.IsValid && tokenB.IsValid && liquidity >= 0 && amountAMin >= 0 && amountBMin >= 0 && deadLine > 0, "Invalid Parameters");
+            Assert(liquidity > 0 && amountAMin >= 0 && amountBMin >= 0, "Invalid Parameters");
             //验证权限
             Assert(Runtime.CheckWitness(sender), "Forbidden");
             //看看有没有超过最后期限
@@ -166,7 +166,7 @@ namespace FlamingoSwapRouter
         public static BigInteger[] RemoveLiquidity(UInt160 tokenA, UInt160 tokenB, BigInteger liquidity, BigInteger amountAMin, BigInteger amountBMin, BigInteger deadLine)
         {
             //验证参数
-            Assert(tokenA.IsValid && tokenB.IsValid && liquidity > 0 && amountAMin >= 0 && amountBMin >= 0 && deadLine > 0, "Invalid Parameters");
+            Assert(liquidity > 0 && amountAMin >= 0 && amountBMin >= 0, "Invalid Parameters");
             //验证权限
             var caller = Runtime.CallingScriptHash;
             Assert(ContractManagement.GetContract(caller) != null, "Forbidden");
@@ -214,8 +214,6 @@ namespace FlamingoSwapRouter
         /// <returns></returns>
         public static BigInteger GetAmountOut(BigInteger amountIn, BigInteger reserveIn, BigInteger reserveOut)
         {
-            //    Assert(amountIn > 0, "amountIn should be positive number");
-            //    Assert(reserveIn > 0 && reserveOut > 0, "reserve should be positive number");
             Assert(amountIn > 0 && reserveIn > 0 && reserveOut > 0, "AmountIn Must > 0");
 
             var amountInWithFee = amountIn * 997;
@@ -234,8 +232,6 @@ namespace FlamingoSwapRouter
         /// <returns></returns>
         public static BigInteger GetAmountIn(BigInteger amountOut, BigInteger reserveIn, BigInteger reserveOut)
         {
-            //Assert(amountOut > 0, "amountOut should be positive number");
-            //Assert(reserveIn > 0 && reserveOut > 0, "reserve should be positive number");
             Assert(amountOut > 0 && reserveIn > 0 && reserveOut > 0, "AmountOut Must > 0");
             var numerator = reserveIn * amountOut * 1000;
             var denominator = (reserveOut - amountOut) * 997;
@@ -320,7 +316,7 @@ namespace FlamingoSwapRouter
         public static bool SwapTokenInForTokenOut(UInt160 sender, BigInteger amountIn, BigInteger amountOutMin, UInt160[] paths, BigInteger deadLine)
         {
             //验证参数
-            Assert(sender.IsValid && amountIn > 0 && amountOutMin >= 0 && paths.Length >= 2 && deadLine > 0, "Invalid Parameters");
+            Assert(amountOutMin >= 0, "Invalid Parameters");
             //验证权限
             Assert(Runtime.CheckWitness(sender), "Forbidden");
             //看看有没有超过最后期限
@@ -339,7 +335,7 @@ namespace FlamingoSwapRouter
         public static bool SwapTokenInForTokenOut(BigInteger amountIn, BigInteger amountOutMin, UInt160[] paths, BigInteger deadLine)
         {
             //验证参数
-            Assert(amountIn > 0 && amountOutMin >= 0 && paths.Length >= 2 && deadLine > 0, "Invalid Parameters");
+            Assert(amountOutMin >= 0, "Invalid Parameters");
             //验证权限
             var caller = Runtime.CallingScriptHash;
             Assert(ContractManagement.GetContract(caller) != null, "Forbidden");
@@ -369,7 +365,7 @@ namespace FlamingoSwapRouter
         public static bool SwapTokenOutForTokenIn(UInt160 sender, BigInteger amountOut, BigInteger amountInMax, UInt160[] paths, BigInteger deadLine)
         {
             //验证参数
-            Assert(sender.IsValid && amountOut > 0 && amountInMax >= 0 && paths.Length >= 2 && deadLine > 0, "Invalid Parameters");
+            Assert(amountInMax >= 0, "Invalid Parameters");
             //验证权限
             Assert(Runtime.CheckWitness(sender), "Forbidden");
             //看看有没有超过最后期限
@@ -388,7 +384,7 @@ namespace FlamingoSwapRouter
         public static bool SwapTokenOutForTokenIn(BigInteger amountOut, BigInteger amountInMax, UInt160[] paths, BigInteger deadLine)
         {
             //验证参数
-            Assert(amountOut > 0 && amountInMax >= 0 && paths.Length >= 2 && deadLine > 0, "Invalid Parameters");
+            Assert(amountInMax >= 0, "Invalid Parameters");
             //验证权限
             var caller = Runtime.CallingScriptHash;
             Assert(ContractManagement.GetContract(caller) != null, "Forbidden");

--- a/Swap/flamingo-contract-swap/flamingo-contract-swap.sln
+++ b/Swap/flamingo-contract-swap/flamingo-contract-swap.sln
@@ -15,7 +15,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FlashLoanTemple", "FlashLoa
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FlamingoSwapFactory", "FlamingoSwapFactory\FlamingoSwapFactory.csproj", "{7F4FDB74-D11E-45A7-B6A0-C85D4528748A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProxyTemplate", "ProxyTemplate\ProxyTemplate.csproj", "{71582763-E444-4646-BCCD-828BE7859047}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ProxyTemplate", "ProxyTemplate\ProxyTemplate.csproj", "{71582763-E444-4646-BCCD-828BE7859047}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FlamingoSwapOrderBook", "FlamingoSwapOrderBook\FlamingoSwapOrderBook.csproj", "{99811C5F-FF6B-465F-A341-E60B13BBCD1B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -51,6 +53,10 @@ Global
 		{71582763-E444-4646-BCCD-828BE7859047}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{71582763-E444-4646-BCCD-828BE7859047}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{71582763-E444-4646-BCCD-828BE7859047}.Release|Any CPU.Build.0 = Release|Any CPU
+		{99811C5F-FF6B-465F-A341-E60B13BBCD1B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{99811C5F-FF6B-465F-A341-E60B13BBCD1B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{99811C5F-FF6B-465F-A341-E60B13BBCD1B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{99811C5F-FF6B-465F-A341-E60B13BBCD1B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
### Problem

Inherit https://github.com/flamingo-finance/flamingo-contract-swap/pull/25. In the past order book and aggregator, we got several problems with the gas fee and [stuck orders](https://gist.github.com/adrian-fjellberg/71e687ae9f8e560e0efcf8a8cabe40b2#read-me). Unpredictable aggregation and the high gas fee of FLUND invocation made it expensive to trade with the first order in book, though cheaper to trade with the following because the fundfee is summarized. The result is, we have to pay a high extra sysfee for transactions so that we can deal with a lonely stuck order at the first of the price queue, and it is costive to avoid it in automatic aggregation.

### What's Done

- [x] Remove the Aggregator contract, let the user decide whether to deal and how much to deal with existing limit orders. Order book only ensures that users add, deal orders and swap the AMM within the price limit, but no longer provides a trading strategy. (Existing orders will be first fulfilled, and the left goes AMM)
- [x] Remove the `buy order price >= sell order price` limit of the order queue, so users will not be forced to trigger any orders before adding a new one in some cases.
- [x] Provide some flexible getter methods like `GetFirstNOrders(UInt160 tokenA, UInt160 tokenB, bool isBuy, uint pos, uint n)`, so that the frontend can query anywhere of the order lists and receipt lists.  

The total gas cost of limit deal is reduced from 0.4 GAS by 0.2 GAS by removing the automatic aggregation in contract, and the extra sysfee can be reduced from 0.3 GAS to 0.07-0.15 GAS or even 0 if we can predict the payment of FLUND and decide whether to trade with the book.

### To Do
The gas payment for clean a stuck order alone are still expensive, they will still get stuck until the next order reach the AMM price. We are considering adding a new endpoint to settle the fundfee instead of doing it in every transaction.

- [x] Record the FLUND payments of every transaction in contract storage instead of paying them immediately. And add a claim method for settlement that allows anyone to transfer the summarized payment to `fundAddress`. That will reduce two 0.03? GAS transfers in every transaction.
- [x] Add more similar order getter methods like `GetFirstNOrders` that takes `orderID` as a parameter instead of the `pos`.

(Evaluating...)